### PR TITLE
Add playback commands

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -103,6 +103,31 @@ export default class SoundscapesPlugin extends Plugin {
 				this.indexMusicLibrary();
 			}, 1000);
 		}
+
+		// adding commands to be run from command palette or bind a hotkey to them
+		this.addCommand({
+			id: "go-to-next-track",
+			name: "Go to next track",
+			callback: () => {
+				this.next();
+			},
+		});
+
+		this.addCommand({
+			id: "go-to-previous-track",
+			name: "Go to previous track",
+			callback: () => {
+				this.previous();
+			},
+		});
+
+		this.addCommand({
+			id: "Play/Pause",
+			name: "Play/Pause current track",
+			callback: () => {
+				console.log(this);
+			},
+		});
 	}
 
 	onunload() {

--- a/main.ts
+++ b/main.ts
@@ -33,8 +33,6 @@ if (process.env.NODE_ENV === "development") {
 	);
 }
 
-let isTrackPlaying: boolean;
-
 export default class SoundscapesPlugin extends Plugin {
 	settings: SoundscapesPluginSettings;
 	settingsObservable: Observable;
@@ -62,7 +60,6 @@ export default class SoundscapesPlugin extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
-		isTrackPlaying = this.settings.autoplay;
 
 		this.currentTrackIndex = this.settings.currentTrackIndex; // Persist the current track when closing and opening
 		this.settingsObservable = new Observable(this.settings);
@@ -128,12 +125,13 @@ export default class SoundscapesPlugin extends Plugin {
 			id: "Play/Pause",
 			name: "Play/Pause current track",
 			callback: () => {
-				if (isTrackPlaying) {
+				if (
+					this.localPlayerStateObservable.getValue().playerState ===
+					PLAYER_STATE.PLAYING
+				) {
 					this.pause();
-					isTrackPlaying = false;
 				} else {
 					this.play();
-					isTrackPlaying = true;
 				}
 			},
 		});
@@ -383,17 +381,11 @@ export default class SoundscapesPlugin extends Plugin {
 
 		this.playButton = this.statusBarItem.createEl("button", {});
 		setIcon(this.playButton, "play");
-		this.playButton.onclick = () => {
-			this.play();
-			isTrackPlaying = true;
-		};
+		this.playButton.onclick = () => this.play();
 
 		this.pauseButton = this.statusBarItem.createEl("button", {});
 		setIcon(this.pauseButton, "pause");
-		this.pauseButton.onclick = () => {
-			this.pause();
-			isTrackPlaying = false;
-		};
+		this.pauseButton.onclick = () => this.pause();
 
 		this.nextButton = this.statusBarItem.createEl("button", {
 			cls: "soundscapesroot-nextbutton",

--- a/main.ts
+++ b/main.ts
@@ -33,6 +33,8 @@ if (process.env.NODE_ENV === "development") {
 	);
 }
 
+let isTrackPlaying: boolean;
+
 export default class SoundscapesPlugin extends Plugin {
 	settings: SoundscapesPluginSettings;
 	settingsObservable: Observable;
@@ -60,6 +62,7 @@ export default class SoundscapesPlugin extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
+		isTrackPlaying = this.settings.autoplay;
 
 		this.currentTrackIndex = this.settings.currentTrackIndex; // Persist the current track when closing and opening
 		this.settingsObservable = new Observable(this.settings);
@@ -125,7 +128,13 @@ export default class SoundscapesPlugin extends Plugin {
 			id: "Play/Pause",
 			name: "Play/Pause current track",
 			callback: () => {
-				console.log(this);
+				if (isTrackPlaying) {
+					this.pause();
+					isTrackPlaying = false;
+				} else {
+					this.play();
+					isTrackPlaying = true;
+				}
 			},
 		});
 	}
@@ -374,11 +383,17 @@ export default class SoundscapesPlugin extends Plugin {
 
 		this.playButton = this.statusBarItem.createEl("button", {});
 		setIcon(this.playButton, "play");
-		this.playButton.onclick = () => this.play();
+		this.playButton.onclick = () => {
+			this.play();
+			isTrackPlaying = true;
+		};
 
 		this.pauseButton = this.statusBarItem.createEl("button", {});
 		setIcon(this.pauseButton, "pause");
-		this.pauseButton.onclick = () => this.pause();
+		this.pauseButton.onclick = () => {
+			this.pause();
+			isTrackPlaying = false;
+		};
 
 		this.nextButton = this.statusBarItem.createEl("button", {
 			cls: "soundscapesroot-nextbutton",


### PR DESCRIPTION
This is the implementation of the feature request #35 (I opened few hours earlier).
Adding commands to the plugin is useful because the user can control their playback without touching the mouse, they can use the command palette or assign hotkeys (keyboard shortcuts) to the commands.
Here is a breakdown of the changes:
- I defined `this.addCommand({})` for three different commands (play next track, play previous track, and toggle play/pause)
- to play next track and previous track, I just used `this.next()` and `this.previous()` respectively
- to play/pause current track, I added a variable to store the track state (whether it is playing or paused) and then make the command toggle the state

I tested the changes and they all work fine
![image](https://github.com/andrewmcgivery/obsidian-soundscapes/assets/100171494/c20f778b-9967-411f-afe7-27b87027b3c8)
